### PR TITLE
Setup auto-build RTD

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,20 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+# Required
+version: 2
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+# Build documentation with MkDocs
+#mkdocs:
+#  configuration: mkdocs.yml
+
+# Optionally build your docs in additional formats such as PDF
+#formats:
+#  - pdf
+# Optionally set the version of Python and requirements required to build your docs
+python:
+   version: 3.7
+   install:
+      - requirements: docs/requirements.txt

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Documentation Status](https://readthedocs.org/projects/open-plan-documentation/badge/?version=latest)](https://open-plan-documentation.readthedocs.io/en/latest/?badge=latest)
+
 Welcome to the open_plan documentation repository,
 
 Here the code of the documentation will be available. If you want to get notified when the code gets uploaded you can send an email to open_plan@rl-institut.de.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,4 @@
+sphinx>=2.3.1
+sphinx_rtd_theme>=0.4.3
+numpydoc>=1.1.0
+pandas>==1.1.3


### PR DESCRIPTION
In order to do the auto-build I had to fiddle with OAuth and webhooks a bit

Under "Third party Access" in the open-plan-tool organisation settings I chose OAuth Application Polica and clicked on "Remove restrictions" and it worked
Then I restricted it again and went in my personal github profile settings under "Integration" -> "Applications" -> click on ReadTheDocs in the link, then grant access to open-plan-tool organisation, then webhook worked

In RTD I could not import automatically repositories from open-plan-tool organisation, so I did create it manually, then I added the webhook on github following https://docs.readthedocs.io/en/latest/integrations.html#github

After checking that the syncing of the integration works, I went to [advanced settings of RTD](https://readthedocs.org/dashboard/open-plan-documentation/advanced/)  and ticked the Build pull requests for this project option (as I could not see the builds being started I checked once more and the option was not ticked anymore, make sure you click on save button down below after ticking

I then added a .readthedocs.yml configuration file

Finally I went to my repository (in that case `open-plan-tool/documentation`) settings -> branch then added branch protection to `main`, then ask status checks to pass prior to merging and then I could search for "readthedocs" and enable rtd status check :D
